### PR TITLE
String -> text

### DIFF
--- a/ch01/classesRating_mapping.json
+++ b/ch01/classesRating_mapping.json
@@ -2,16 +2,16 @@
 	"class" : {
 		"properties" : {
 			"title" : {
-				"type" : "string"
+				"type" : "text"
 			},
 			"professor" : {
-				"type" : "string"
+				"type" : "text"
 			},
 			"major" : {
-				"type" : "string"
+				"type" : "text"
 			},
 			"semester" : {
-				"type" : "string"
+				"type" : "text"
 			},
 			"student_count" : {
 				"type" : "integer"


### PR DESCRIPTION
elasticsearch에서 더이상 String type을 사용하지 않고 text을 사용한다고 합니다.

https://stackoverflow.com/questions/47452770/no-handler-for-type-string-declared-on-field-name